### PR TITLE
Improve code quality based on review comments.

### DIFF
--- a/src/main/java/duke/command/Command.java
+++ b/src/main/java/duke/command/Command.java
@@ -64,7 +64,7 @@ public class Command {
      *
      * @param arg Argument in string.
      * @return Argument in enumeration.
-     * @throws IllegalArgumentException if input string is not a valid enum.
+     * @throws IllegalArgumentException If input string is not a valid enum.
      */
     public static Argument parseArgument(String arg)
             throws IllegalArgumentException {
@@ -83,7 +83,7 @@ public class Command {
      * Checks if the command contains an argument key.
      *
      * @param arg Argument to check.
-     * @return true if the argument exists, false otherwise.
+     * @return true If the argument exists, false otherwise.
      */
     public boolean hasArg(Argument arg) {
         return arguments.containsKey(arg);
@@ -93,7 +93,7 @@ public class Command {
      * Checks if a specific argument in command has a value.
      *
      * @param arg Argument to check.
-     * @return true if argument exists and value is a non-empty string,
+     * @return true If argument exists and value is a non-empty string,
      *         false otherwise.
      */
     public boolean hasValue(Argument arg) {

--- a/src/main/java/duke/command/Parser.java
+++ b/src/main/java/duke/command/Parser.java
@@ -19,12 +19,12 @@ public class Parser {
         LinkedHashMap<Command.Argument, String> arguments = new LinkedHashMap<>();
         for (String term : input.strip().split(" /")) {
             int firstSpace = term.indexOf(" ");
-            Command.Argument argument = Command.parseArgument((firstSpace == -1
+            Command.Argument argument = Command.parseArgument((firstSpace == -1)
                     ? term
-                    : term.substring(0, firstSpace)));
-            String value = (firstSpace == -1
+                    : term.substring(0, firstSpace));
+            String value = (firstSpace == -1)
                     ? ""
-                    : term.substring(firstSpace + 1));
+                    : term.substring(firstSpace + 1);
             arguments.put(argument, value);
         }
         Command command = new Command(arguments);
@@ -36,7 +36,7 @@ public class Parser {
      * Checks if the Command's arguments are valid.
      *
      * @param command Command to check.
-     * @throws IllegalArgumentException if arguments are invalid.
+     * @throws IllegalArgumentException If arguments are invalid.
      */
     private static void checkArguments(Command command)
             throws IllegalArgumentException {
@@ -80,7 +80,7 @@ public class Parser {
      *
      * @param command Command to check.
      * @param args Required arguments.
-     * @throws IllegalArgumentException if any of the required arguments are not in
+     * @throws IllegalArgumentException If any of the required arguments are not in
      *                                  the command.
      */
     private static void checkHasArgs(Command command, ArrayList<Command.Argument> args)
@@ -97,7 +97,7 @@ public class Parser {
      * Checks if a command's arguments contain non-empty values.
      * @param command Command to check.
      * @param args Arguments with required values.
-     * @throws IllegalArgumentException if any of the arguments  are not in the
+     * @throws IllegalArgumentException If any of the arguments  are not in the
      *                                  command or have empty values.
      */
     private static void checkHasValues(Command command, ArrayList<Command.Argument> args)

--- a/src/main/java/duke/task/TaskList.java
+++ b/src/main/java/duke/task/TaskList.java
@@ -53,7 +53,7 @@ public class TaskList {
      * Executes a given command.
      *
      * @param command Command to be executed.
-     * @return The task involved in the command.
+     * @return Task involved in the command.
      */
     public Task execute(Command command) {
         Task task = null;
@@ -95,7 +95,7 @@ public class TaskList {
     /**
      * Saves the task list to disk.
      *
-     * @throws IOException when there is an exception when writing to file or directory.
+     * @throws IOException When there is an exception when writing to file or directory.
      */
     public void save(FileWriter fileWriter) throws IOException {
         for (int i = 0; i < tasks.size(); i++) {

--- a/src/main/java/duke/ui/DialogBox.java
+++ b/src/main/java/duke/ui/DialogBox.java
@@ -15,16 +15,27 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 
 /**
- * An example of a custom control using FXML.
- * This control represents a dialog box consisting of an ImageView to represent the speaker's face and a label
+ * Controller for DialogBox.
+ * Dialog box consists of an ImageView to represent the speaker's face and a label
  * containing text from the speaker.
  */
 public class DialogBox extends HBox {
+
+    /** Label containing text for dialog */
     @FXML
     private Label dialog;
+
+    /** ImageView containing the display picture for the dialog */
     @FXML
     private ImageView displayPicture;
 
+    /**
+     * Constructs a new DialogBox.
+     * Dialog boxes should be constructed using the public factory methods.
+     *
+     * @param text Text to display inside DialogBox.
+     * @param img Display image for the DialogBox.
+     */
     private DialogBox(String text, Image img) {
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/DialogBox.fxml"));
@@ -49,10 +60,24 @@ public class DialogBox extends HBox {
         setAlignment(Pos.TOP_LEFT);
     }
 
+    /**
+     * Creates a new dialog box for the user.
+     *
+     * @param text Text to display inside DialogBox.
+     * @param img Display image for the DialogBox.
+     * @return Dialog box for the user.
+     */
     public static DialogBox getUserDialog(String text, Image img) {
         return new DialogBox(text, img);
     }
 
+    /**
+     * Creates a new dialog box for the duke.
+     *
+     * @param text Text to display inside DialogBox.
+     * @param img Display image for the DialogBox.
+     * @return Dialog box for the duke.
+     */
     public static DialogBox getDukeDialog(String text, Image img) {
         var db = new DialogBox(text, img);
         db.flip();

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -10,8 +10,10 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
+
 /**
- * Controller for MainWindow. Provides the layout for the other controls.
+ * Controller for MainWindow.
+ * Provides the layout for the other controls.
  */
 public class MainWindow extends AnchorPane {
 
@@ -131,6 +133,7 @@ public class MainWindow extends AnchorPane {
 
     /**
      * Displays tasks containing a certain keyword
+     *
      * @param tasks String representation of filtered tasks.
      */
     public void showTasksWithKeyword(String tasks) {


### PR DESCRIPTION
Some javadoc comments are written without capitalisation, some new lines are missing and some ternary operators are too long.

This makes the code inconsistent and hard to read.

Let's fix these issues according to the SE-EDU coding quality recommendations.
* add a new line after the import before the class comment.
* capitalise all @throws description in javadocs.
* rearrange parenthesis for long ternary operators.